### PR TITLE
Add Imprint and Data Protection Policy links to footer complying with German Telemedia Act (TMG) and Federal Act on Privacy in Telecommunications and Telemedia (TTSDG)

### DIFF
--- a/src/views/DashboardContainer.vue
+++ b/src/views/DashboardContainer.vue
@@ -55,6 +55,8 @@
 
           <div class="col-md-4 d-flex align-items-center justify-content-center">
             <a @click.prevent="showChangelog" href="#" class="text-muted">{{ $t('pageFooterVersion', { version: germinateVersion }) }}</a>
+            <a class="text-muted ml-3" v-if="$te('pageFooterImprintURL')" :href="$t('pageFooterImprintURL')" target="_blank" rel="noopener noreferrer">{{ $t('pageFooterImprint') }}</a>
+            <a class="text-muted ml-3" v-if="$te('pageFooterDataProtectionURL')" :href="$t('pageFooterDataProtectionURL')" target="_blank" rel="noopener noreferrer">{{ $t('pageFooterDataProtection') }}</a>
           </div>
 
           <ul class="nav col-md-4 justify-content-center justify-content-md-end list-unstyled d-flex">


### PR DESCRIPTION
This commit introduces two new links: **Imprint** and **Data Protection Policy** into the footer visible throughout the Germinate's Platform.

According to the [German Telemedia Act (TMG)](https://secureprivacy.ai/blog/what-is-an-impressum), all commercial and government websites operating in Germany are legally required to provide clear and accessible information including:

- Name and legal address of the responsible entity.
- Legal form if the entity is a legal person (e.g., GmbH, AG).
- Contact details, including an email address for responsible parties.
- Details of commercial registration, such as register name and registration number.

Adding these links pointing to pages that provide this kind of information ensures that the Germinate Platform complies with these transparency and disclosure obligations, improving legal compliance and user trust. The Imprint page presents all required legal entity information, while the [Data Protection Policy](https://secureprivacy.ai/blog/germany-federal-act-on-privacy-in-telecommunications-and-telemedia) link directs users to details on how their data is processed and protected (Germany Federal Act on Privacy in Telecommunications and Telemedia - TTSDG).

This update supports Germinate’s commitment to maintain compliance with applicable legal frameworks and to provide clear, transparent information to its users. _**Knowing that this configuration meets regulations in Germany, an if operator was added that checks whether the configuration exists, otherwise the links are not displayed.**_